### PR TITLE
Updated url for tab creation

### DIFF
--- a/source/popup.js
+++ b/source/popup.js
@@ -1,5 +1,5 @@
 var openFeedly = function(url){
-	chrome.tabs.create({url: 'http://cloud.feedly.com/#subscription/feed/' + escape(url)});
+	chrome.tabs.create({url: 'http://feedly.com/i/subscription/feed/' + escape(url)});
 }
 
 var onClick = function(event){


### PR DESCRIPTION
Feedly has changed the format for the URL. Old one just goes back to home page.
